### PR TITLE
Added parse tree equivalence understandings

### DIFF
--- a/structured.js
+++ b/structured.js
@@ -498,9 +498,6 @@
         if (options.single) {
             return false;
         }
-        //avoid children accidentally preventing testing alternate nodes
-        var oldRecurse = options.recurse;
-        options.recurse = false;
         // Check children.
         for (var key in currTree) {
             if (!currTree.hasOwnProperty(key) || !_.isObject(currTree[key])) {
@@ -514,10 +511,10 @@
                 return matchResults;
             }
         }
-        options.recurse = oldRecurse;
-        var mod = restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options);
-        if (mod && !options.recurse) {
-            options.recurse = true;
+        var newops = deepClone(options);
+        newops.hasRecursed = true;
+        var mod = restructureTree(currTree, toFind, peersToFind, wVars, matchResults, newops);
+        if (mod) {
             return checkMatchTree(mod, toFind, peersToFind, wVars, matchResults, options);
         }
         return false;
@@ -528,6 +525,9 @@
         Takes an argument list identical to checkMatchTree() above
     */
     function restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
+        if (options.hasRecursed) {
+            return false;
+        }
         var r = deepClone(currTree);
         if (currTree.type === "BinaryExpression" && _.contains(["+", "*"], currTree.operator)) {
             r.left = currTree.right;

--- a/structured.js
+++ b/structured.js
@@ -512,7 +512,7 @@
                 return matchResults;
             }
         }
-        if (!recursing && !options.orderMatters) {
+        if (!recursing) {
             var mod = restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options);
             if (mod) {
                 return checkMatchTree(mod, toFind, peersToFind, wVars, matchResults, options, true);
@@ -527,7 +527,7 @@
     */
     function restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         var r = deepClone(currTree);
-        if (currTree.type === "BinaryExpression" && _.contains(["+", "*"], currTree.operator)) {
+        if (currTree.type === "BinaryExpression" && _.contains(["+", "*"], currTree.operator) && !options.orderMatters) {
             r.left = currTree.right;
             r.right = currTree.left;
             return r;

--- a/structured.js
+++ b/structured.js
@@ -536,9 +536,6 @@
         }
         else if (currTree.type === "AssignmentExpression") {
             if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], currTree.operator)) {
-                alert(currTree.operator);
-                alert(typeof currTree.operator);
-                alert(currTree.operator.slice(0,-1));
                 return {type: "AssignmentExpression",
                         operator: "=",
                         left: currTree.left,

--- a/structured.js
+++ b/structured.js
@@ -506,16 +506,16 @@
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, false)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, false))) {
                 return matchResults;
             }
         }
-        if (recursing) {
+        if (!recursing && !options.orderMatters) {
             var mod = restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options);
             if (mod) {
-                return checkMatchTree(mod, toFind, peersToFind, wVars, matchResults, options);
+                return checkMatchTree(mod, toFind, peersToFind, wVars, matchResults, options, true);
             }
         }
         return false;

--- a/structured.js
+++ b/structured.js
@@ -477,10 +477,10 @@
      * toFind: The syntax node from the structure that we wish to find.
      * peersToFind: The remaining ordered syntax nodes that we must find after
      *     toFind (and on the same level as toFind).
-     * recursing: is this function being called after a modification by RestructureTree()?
+     * modify: should it call RestructureTree()?
      */
-    function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options, recursing) {
-        if (typeof recursing === 'undefined') {recursing = false;}
+    function checkMatchTree(currTree, toFind, peersToFind, wVars, matchResults, options, modify) {
+        if (typeof modify === 'undefined') {modify = false;}
         if (_.isArray(toFind)) {
             console.error("toFind should never be an array.");
             console.error(toFind);
@@ -507,16 +507,16 @@
             }
             // Recursively check for matches
             if ((_.isArray(currTree[key]) &&
-                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, false)) ||
+                    checkNodeArray(currTree[key], toFind, peersToFind, wVars, matchResults, options, true)) ||
                 (!_.isArray(currTree[key]) &&
-                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, false))) {
+                    checkMatchTree(currTree[key], toFind, peersToFind, wVars, matchResults, options, true))) {
                 return matchResults;
             }
         }
-        if (!recursing) {
+        if (modify) {
             var mod = restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options);
             if (mod) {
-                return checkMatchTree(mod, toFind, peersToFind, wVars, matchResults, options, true);
+                return checkMatchTree(mod, toFind, peersToFind, wVars, matchResults, options, false);
             }
         }
         return false;

--- a/tests.js
+++ b/tests.js
@@ -292,7 +292,7 @@ var nestedTests = function() {
             console.log(x); \n \
         } \n ";
         ok(Structured.match(code, structure),
-            "More complex nested if with distractions matches.");
+            "More complex nested if with distraction matches.");
 
         code = "  \
         var x = 30; \n \
@@ -729,7 +729,8 @@ var varCallbackTests = function() {
         code = ("tree += 30 + 50 + 70; plant(40, 0) + forest(30, 30);" +
             "tree += 30 + 50 + 10; plant(40, 0) + forest(30, 60);");
         result = Structured.match(code, structure, {
-            "varCallbacks": varCallbacks
+            "varCallbacks": varCallbacks,
+            "orderMatters": true
         });
         equal(result, false, "False multiple multiple-var callbacks work.");
         equal(varCallbacks.failure, undefined,
@@ -1839,6 +1840,36 @@ var altVarCallbacks = function(){
     });
 };
 
+var commutativity = function(){
+    QUnit.module("Checking basic commutative equivalence");
+
+    test("--", function() {
+        structure = function() {
+            $a = $a + 1;
+        };
+        code = "a += 1;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "match += to = +");
+
+        structure = function() {
+            $a += 1;
+        };
+        code = "a = a + 1;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "match = + to +=");
+
+        structure = function() {
+            $a + 7;
+        };
+        code = "7 + a;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of addition");
+        
+        structure = function() {
+            7 * $a;
+        };
+        code = "a * 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of multiplication");
+    });
+};
+
 var runAll = function() {
     basicTests();
     clutterTests();
@@ -1853,6 +1884,7 @@ var runAll = function() {
     structureMatchTests();
     injectDataTests();
     altVarCallbacks();
+    commutativity();
 };
 
 runAll();


### PR DESCRIPTION
I have added a simple parse tree modifier that makes
```3 * 4``` match ```4 * 3```
and
```i = i + 3``` match ```i += 3``` and vice versa.
I have done my best to test it, though I have not checked anything much more complicated than the above.