### PR TITLE
More parse tree equivalence understandings

### DIFF
--- a/structured.js
+++ b/structured.js
@@ -527,14 +527,35 @@
      * Takes an argument list identical to checkMatchTree() above, with the exception of the recursing parameter
      * Transformations:
      *   a * b => b * a
+     *   a + b => b + a
+     *   a < b => b > a
+     *   a > b => b < a
+     *   a <= b => b >= a
+     *   a >= b => b <= a
      *   a += b => a = a + b
      *   a = a + b => a += b
      */
     function restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         var r = deepClone(currTree);
-        if (currTree.type === "BinaryExpression" && _.contains(["+", "*"], currTree.operator) && !options.orderMatters) {
+        if (currTree.type === "BinaryExpression" && _.contains(["+", "*", "<", ">", "<=", ">="], currTree.operator) && !options.orderMatters) {
             r.left = currTree.right;
             r.right = currTree.left;
+            switch (currTree.operator) {
+                case "<":
+                    r.operator = ">";
+                    break;
+                case ">":
+                    r.operator = "<";
+                    break;
+                case "<=":
+                    r.operator = ">=";
+                    break;
+                case ">=":
+                    r.operator = "<=";
+                    break;
+                default: //+, *
+                    r.operator = currTree.operator;
+            }
             return r;
         } else if (currTree.type === "AssignmentExpression") {
             if (_.contains(["+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|="], currTree.operator)) {

--- a/tests.js
+++ b/tests.js
@@ -1867,6 +1867,30 @@ var commutativity = function(){
         };
         code = "a * 7;"; 
         equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of multiplication");
+        
+        structure = function() {
+            7 < $a;
+        };
+        code = "a > 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a > 7 matches 7 < a");
+        
+        structure = function() {
+            7 > $a;
+        };
+        code = "a < 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a < 7 matches 7 > a");
+        
+        structure = function() {
+            7 <= $a;
+        };
+        code = "a >= 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a >= 7 matches 7 <= a");
+        
+        structure = function() {
+            7 >= $a;
+        };
+        code = "a <= 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a <= 7 matches 7 >= a");
     });
 };
 


### PR DESCRIPTION
I have extended the changes I made in https://github.com/Khan/structuredjs/pull/10 to include
```a < b``` matches ```b > a```
and
```a <= b``` matches ```b >= a```
and vice versa for both.

Tests have been included and it should be backwards compatible (assuming that what I did last time was).