### PR TITLE
Yet more parse tree equivalence understandings

### DIFF
--- a/structured.js
+++ b/structured.js
@@ -534,6 +534,8 @@
      *   a >= b => b <= a
      *   a += b => a = a + b
      *   a = a + b => a += b
+     *   a++ => a += 1
+     *   a-- => a -= 1
      */
     function restructureTree(currTree, toFind, peersToFind, wVars, matchResults, options) {
         var r = deepClone(currTree);
@@ -576,6 +578,13 @@
                              right: currTree.right.right};
             }
             return false;
+        } else if (currTree.type === "UpdateExpression" && _.contains(["++", "--"], currTree.operator)) {
+            return {type: "AssignmentExpression",
+                    operator: currTree.operator[0] + "=",
+                    left: currTree.argument,
+                    right: {type: "Literal",
+                            value: 1,
+                            raw: "1"}};
         }
         return false;
     }

--- a/tests.js
+++ b/tests.js
@@ -1891,6 +1891,18 @@ var commutativity = function(){
         };
         code = "a <= 7;"; 
         equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a <= 7 matches 7 >= a");
+        
+        structure = function() {
+            $a += 1;
+        };
+        code = "a++;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a++ matches a += 1");
+        
+        structure = function() {
+            $a -= 1;
+        };
+        code = "a--;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a-- matches a -= 1");
     });
 };
 


### PR DESCRIPTION
I intended to include this in the previous pull request, not expecting it to merged quite so quickly.
This will transform ```a++``` into ```a += 1``` and ```a--``` into ```a -= 1```
Unfortunately, due to the recursion protection, it will be somewhat difficult to do the reverse unless I make it so that the tree is modfied first to a common "simplest form" and then the matching is attempted. I will mess with this more if I get around to it.