### PR TITLE
And still more parse tree equivalence understandings

### DIFF
--- a/structured.js
+++ b/structured.js
@@ -599,7 +599,7 @@
                     right: {type: "Literal",
                             value: 1,
                             raw: "1"}};
-        } else if ("body" in currTree && !options.notvar) {
+        } /*else if ("body" in currTree && !options.notvar) {
             var splices = [];
             for (var i = 0; i < currTree.body.length; i++) {
                 if (currTree.body[i].type === "VariableDeclaration") {
@@ -626,7 +626,7 @@
             } else {
                 return false;
             }
-        }
+        } */
         return false;
     }
 

--- a/structured.js
+++ b/structured.js
@@ -599,7 +599,9 @@
                     right: {type: "Literal",
                             value: 1,
                             raw: "1"}};
-        } /*else if ("body" in currTree && !options.notvar) {
+        }
+        //This section would transform "var x = 3;" to "var x; x = 3;" though it has issues.
+        /*else if ("body" in currTree && !options.notvar) {
             var splices = [];
             for (var i = 0; i < currTree.body.length; i++) {
                 if (currTree.body[i].type === "VariableDeclaration") {

--- a/tests.js
+++ b/tests.js
@@ -1969,13 +1969,6 @@ var commutativity = function(){
         };
         code = "7 || a;"; 
         equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ||");
-
-        /*structure = function() {
-            var $a;
-            $a = 7;
-        };
-        code = "var a = 7;"; 
-        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "var a = 7 matches var a; a = 7"); */
     });
 };
 

--- a/tests.js
+++ b/tests.js
@@ -927,7 +927,7 @@ var wildcardVarTests = function() {
             z = 'eaglee'.length;   \n \
         }   \n \
         ";
-        equal(Structured.match(code, structure), //, {notvar: true}),
+        equal(Structured.match(code, structure),
             false, "Complex vars with small mismatch breaks.");
 
     });
@@ -956,7 +956,7 @@ var nestingOrder = function() {
                 function() {
                     var x = 5;
                     var y = 6;
-                }),//, {notvar:true}),
+                }),
             "Upward expression ordering fails.")
     });
 };

--- a/tests.js
+++ b/tests.js
@@ -927,7 +927,7 @@ var wildcardVarTests = function() {
             z = 'eaglee'.length;   \n \
         }   \n \
         ";
-        equal(Structured.match(code, structure, {notvar: true}),
+        equal(Structured.match(code, structure), //, {notvar: true}),
             false, "Complex vars with small mismatch breaks.");
 
     });
@@ -956,7 +956,7 @@ var nestingOrder = function() {
                 function() {
                     var x = 5;
                     var y = 6;
-                }, {notvar:true}),
+                }),//, {notvar:true}),
             "Upward expression ordering fails.")
     });
 };
@@ -1970,12 +1970,12 @@ var commutativity = function(){
         code = "7 || a;"; 
         equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ||");
 
-        structure = function() {
+        /*structure = function() {
             var $a;
             $a = 7;
         };
         code = "var a = 7;"; 
-        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "var a = 7 matches var a; a = 7");
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "var a = 7 matches var a; a = 7"); */
     });
 };
 

--- a/tests.js
+++ b/tests.js
@@ -927,7 +927,7 @@ var wildcardVarTests = function() {
             z = 'eaglee'.length;   \n \
         }   \n \
         ";
-        equal(Structured.match(code, structure),
+        equal(Structured.match(code, structure, {notvar: true}),
             false, "Complex vars with small mismatch breaks.");
 
     });
@@ -956,7 +956,7 @@ var nestingOrder = function() {
                 function() {
                     var x = 5;
                     var y = 6;
-                }),
+                }, {notvar:true}),
             "Upward expression ordering fails.")
     });
 };
@@ -1903,6 +1903,79 @@ var commutativity = function(){
         };
         code = "a--;"; 
         equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "a-- matches a -= 1");
+        
+        structure = function() {
+            true && false;
+        };
+        code = "false && true;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "true && false matches false && true");
+        
+        structure = function() {
+            ($a === 3) || true;
+        };
+        code = "true || (a === 3);"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "true || (a === 3) matches (a === 3) || true");
+
+        structure = function() {
+            $a === 7;
+        };
+        code = "7 === a;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ===");
+        
+        structure = function() {
+            7 != $a;
+        };
+        code = "a != 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of !=");
+
+        structure = function() {
+            $a !== 7;
+        };
+        code = "7 !== a;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of !==");
+        
+        structure = function() {
+            7 == $a;
+        };
+        code = "a == 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ==");
+
+        structure = function() {
+            $a & 7;
+        };
+        code = "7 & a;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of &");
+        
+        structure = function() {
+            7 | $a;
+        };
+        code = "a | 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of |");
+
+        structure = function() {
+            $a ^ 7;
+        };
+        code = "7 ^ a;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ^");
+        
+        structure = function() {
+            7 && $a;
+        };
+        code = "a && 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of &&");
+
+        structure = function() {
+            $a || 7;
+        };
+        code = "7 || a;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ||");
+
+        structure = function() {
+            var $a;
+            $a = 7;
+        };
+        code = "var a = 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "var a = 7 matches var a; a = 7");
     });
 };
 


### PR DESCRIPTION
Perhaps I should have done more of these edits *before* making the pull requests. :)
This time I have added ```===```, ```!==```, ```!=```, ```==```, ```&```, ```|```, ```^```, ```&&```, ```||``` and I have now exhausted the list of JS operators that can be treated this way. They all have tests, of course.

Now for the more interesting part:
```var a = 3``` will now be transformed into ```var a; a = 3``` but not vice versa.
This works, but there are 2 tests that fail:
* [Complex vars with small mismatch breaks.](https://github.com/mr-martian/structuredjs/blob/master/tests.js#L959)
* [Upward expression ordering fails.](https://github.com/mr-martian/structuredjs/blob/master/tests.js#L930)

The former appears to be testing something that is only slightly wrong, and broken by the modification.

The latter is checking that ```while(true) { var x = 5; } var y = 6;``` does not match ```var x = 5; var y = 6;```, which appearantly it now does.

So should I remove this part and just leave every commutative operator? For the moment I have added an option to prevent this change from being applied, which is passed by the tests that failed. This does not seem like an optimal solution, perhaps those particular tests need to be changed?