### PR TITLE
Transforming tree to "standard form"

### DIFF
--- a/structured.js
+++ b/structured.js
@@ -59,13 +59,13 @@
      * return true if n2 < n1 (according to relatively arbitrary criteria)
      */
     function shouldSwap(n1, n2) {
-	if (n1.type < n2.type) {
+	if (n1.type < n2.type) { //Sort by node type if different
 	    return false;
 	} else if (n1.type > n2.type) {
 	    return true;
-	} else if (n1.type === "Literal") {
+	} else if (n1.type === "Literal") { //Sort by value if they're literals
 	    return n1.raw > n2.raw
-	} else {
+	} else { //Otherwise, loop through the properties until a difference is found and sort by that
 	    for (var k in n1) {
 		if (n1[k].hasOwnProperty("type") && n1[k] !== n2[k]) {
 		    return shouldSwap(n1[k], n2[k]);
@@ -118,7 +118,7 @@
 					 value: 1,
 					 raw: "1"}}};
 		} break;
-	    /*case "VariableDeclaration":
+	    case "VariableDeclaration":
 	        if (tree.kind === "var") {
 		    r = [deepClone(tree)];
 		    for (var i in tree.declarations) {
@@ -132,7 +132,7 @@
 			    r[0].declarations[i].init = null;
 			}
 		    }
-		} break; */
+		} break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/structured.js
+++ b/structured.js
@@ -118,21 +118,21 @@
 					 value: 1,
 					 raw: "1"}}};
 		} break;
-	    case "VariableDeclarations":
+	    /*case "VariableDeclaration":
 	        if (tree.kind === "var") {
-		    var ar = [r];
+		    r = [deepClone(tree)];
 		    for (var i in tree.declarations) {
-			if (tree.declarations[i].type === "VariableDeclaration" &&
+			if (tree.declarations[i].type === "VariableDeclarator" &&
 			    tree.declarations[i].init !== null) {
-			    ar.push({type: "ExpressionStatement",
-				     expression: {type: "AssignmentExpression",
-						  operator: "=",
-						  left: tree.declarations[i].id,
-						  right: standardizeTree(tree.declarations[i].init)}});
-			    ar[0].declarations[i].init = null;
+			    r.push({type: "ExpressionStatement",
+				    expression: {type: "AssignmentExpression",
+						 operator: "=",
+						 left: tree.declarations[i].id,
+						 right: standardizeTree(tree.declarations[i].init)}});
+			    r[0].declarations[i].init = null;
 			}
 		    }
-		} break;
+		} break; */
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/tests.js
+++ b/tests.js
@@ -984,11 +984,7 @@ var structureMatchTests = function() {
                         "type": "Identifier",
                         "name": "x"
                     },
-                    "init": {
-                        "raw": "5",
-                        "type": "Literal",
-                        "value": 5
-                    }
+                    "init": null
                 }],
                 "kind": "var"
             }
@@ -1013,11 +1009,7 @@ var structureMatchTests = function() {
                         "type": "Identifier",
                         "name": "x"
                     },
-                    "init": {
-                        "raw": "5",
-                        "type": "Literal",
-                        "value": 5
-                    }
+                    "init": null
                 }],
                 "kind": "var"
             }
@@ -1055,11 +1047,7 @@ var structureMatchTests = function() {
                         "type": "Identifier",
                         "name": "x"
                     },
-                    "init": {
-                        "raw": "5",
-                        "type": "Literal",
-                        "value": 5
-                    }
+                    "init": null
                 }],
                 "kind": "var"
             }
@@ -1071,16 +1059,9 @@ var structureMatchTests = function() {
                 "type": "Identifier",
                 "name": "x"
             },
-            "init": {
-                "type": "Identifier",
-                "name": "_"
-            }
+            "init": null
         }), {
-            "_": [{
-                "raw": "5",
-                "type": "Literal",
-                "value": 5
-            }],
+            "_": [],
             "vars": {},
             "root": {
                 "type": "VariableDeclarator",
@@ -1088,11 +1069,7 @@ var structureMatchTests = function() {
                     "type": "Identifier",
                     "name": "x"
                 },
-                "init": {
-                    "raw": "5",
-                    "type": "Literal",
-                    "value": 5
-                }
+                "init": null
             }
         }, "Verify primitive with simple object AST.");
 
@@ -1148,13 +1125,7 @@ var structureMatchTests = function() {
             var x = $a;
         }), {
             "_": [],
-            "vars": {
-                "a": {
-                    "raw": "5",
-                    "type": "Literal",
-                    "value": 5
-                }
-            },
+            "vars": {},
             "root": {
                 "type": "VariableDeclaration",
                 "declarations": [{
@@ -1163,11 +1134,7 @@ var structureMatchTests = function() {
                         "type": "Identifier",
                         "name": "x"
                     },
-                    "init": {
-                        "raw": "5",
-                        "type": "Literal",
-                        "value": 5
-                    }
+                    "init": null
                 }],
                 "kind": "var"
             }
@@ -1195,14 +1162,25 @@ var structureMatchTests = function() {
                                 "type": "Identifier",
                                 "name": "a"
                             },
-                            "init": {
-                                "raw": "5",
-                                "type": "Literal",
-                                "value": 5
-                            }
+                            "init": null
                         }],
                         "kind": "var"
                     }, {
+                        "expression":  {
+                          "left": {
+                            "name": "a",
+                            "type": "Identifier"
+                          },
+                          "operator": "=",
+                          "right": {
+                            "raw": "5",
+                            "type": "Literal",
+                            "value": 5
+                          },
+                          "type": "AssignmentExpression"
+                        },
+                        "type": "ExpressionStatement"
+                      }, {
                         "type": "ExpressionStatement",
                         "expression": {
                             "type": "CallExpression",
@@ -1231,14 +1209,25 @@ var structureMatchTests = function() {
                                     "type": "Identifier",
                                     "name": "a"
                                 },
-                                "init": {
-                                    "raw": "5",
-                                    "type": "Literal",
-                                    "value": 5
-                                }
+                                "init": null
                             }],
                             "kind": "var"
                         }, {
+                            "expression":  {
+                              "left": {
+                                "name": "a",
+                                "type": "Identifier"
+                              },
+                              "operator": "=",
+                              "right": {
+                                "raw": "5",
+                                "type": "Literal",
+                                "value": 5
+                              },
+                              "type": "AssignmentExpression"
+                            },
+                            "type": "ExpressionStatement"
+                          }, {
                             "type": "ExpressionStatement",
                             "expression": {
                                 "type": "CallExpression",
@@ -1475,6 +1464,9 @@ var structureMatchTests = function() {
                 "type": "Identifier",
                 "name": "a"
             }, {
+                "type": "Identifier",
+                "name": "a"
+            }, {
                 "type": "FunctionExpression",
                 "id": null,
                 "params": [],
@@ -1496,19 +1488,7 @@ var structureMatchTests = function() {
                         "type": "Identifier",
                         "name": "a"
                     },
-                    "init": {
-                        "type": "FunctionExpression",
-                        "id": null,
-                        "params": [],
-                        "defaults": [],
-                        "body": {
-                            "type": "BlockStatement",
-                            "body": []
-                        },
-                        "rest": null,
-                        "generator": false,
-                        "expression": false
-                    }
+                    "init": null
                 }],
                 "kind": "var"
             }
@@ -1549,11 +1529,7 @@ var structureMatchTests = function() {
                             "type": "Identifier",
                             "name": "a"
                         },
-                        "init": {
-                            "raw": "5",
-                            "type": "Literal",
-                            "value": 5
-                        }
+                        "init": null
                     }],
                     "kind": "var"
                 }, {
@@ -1612,11 +1588,7 @@ var structureMatchTests = function() {
                             "type": "Identifier",
                             "name": "a"
                         },
-                        "init": {
-                            "raw": "5",
-                            "type": "Literal",
-                            "value": 5
-                        }
+                        "init": null
                     }],
                     "kind": "var"
                 }, {
@@ -1969,6 +1941,12 @@ var commutativity = function(){
         };
         code = "7 || a;"; 
         equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "commutative property of ||");
+
+        structure = function() {
+            var $a = 7;
+        };
+        code = "var a; a = 7;"; 
+        equal(!!Structured.match(code, structure, {editorCallbacks: {}}), true, "var a = 7 matches var a; a = 7");
     });
 };
 


### PR DESCRIPTION
As requested in #14, I have made the tree modification be something done once beforehand, transforming both the code and the structure to standard form.

All increment, decrement, ```+=```, etc. will become ```a = a + b``` (or whatever is appropriate, it will not turn every assignment into something referring to the variable ```a```)

For commutative operators, nodes are sorted lexiographically by type, by value if they are ```Literal``` nodes, then finally by iterating the comparison over child nodes.

```>``` and ```>=``` become ```<``` and ```<=``` respectively.

Lines 121 to 135, if uncommented, will allow ```var a; a = 3;``` to match ```var a = 3;```, however it caused several other tests to fail, so I commented it and will continue attempting to fix it.