### PR TITLE
Ignore different quoting styles of strings

### DIFF
--- a/structured.js
+++ b/structured.js
@@ -82,7 +82,10 @@
 		    if (shouldSwap(tree.left, tree.right)) {
 			r.left = standardizeTree(tree.right);
 			r.right = standardizeTree(tree.left);
-		    }
+            } else {
+                r.left = standardizeTree(tree.left);
+                r.right = standardizeTree(tree.right);
+            }
 		} else if (tree.operator[0] === ">") {
 		    r.operator = "<" + tree.operator.slice(1);
 		    r.left = standardizeTree(tree.right);
@@ -104,7 +107,10 @@
 				 operator: tree.operator.slice(0,-1),
 				 left: l,
 				 right: standardizeTree(tree.right)}};
-		} break;
+		} else {
+            r.left = standardizeTree(r.left);
+            r.right = standardizeTree(r.right);
+        } break;
 	    case "UpdateExpression":
 	        if (_.contains(["++", "--"], tree.operator)) {
 		    var l = standardizeTree(tree.argument);
@@ -133,6 +139,11 @@
 			}
 		    }
 		} break;
+        case "Literal":
+            r.raw = tree.
+                raw.replace(/^(?:"|')(.+)(?:"|')$/, function(match, p1) {
+                return "\"" + p1.replace(/"|'/g, "\"") + "\"";
+            }); break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/structured.js
+++ b/structured.js
@@ -140,10 +140,12 @@
 		    }
 		} break;
         case "Literal":
-            r.raw = tree.
-                raw.replace(/^(?:"|')(.+)(?:"|')$/, function(match, p1) {
-                return "\"" + p1.replace(/"|'/g, "\"") + "\"";
-            }); break;
+            r.raw = tree.raw
+                .replace(/^(?:\"(.*?)\"|\'(.*?)\')$/, function(match, p1, p2) {
+                    return "\"" + ((p1 || "") + (p2 || ""))
+                        .replace(/"|'/g, "\"") + "\"";
+                });
+            console.log(r.raw); break;
 	    default:
 	        for (var key in tree) {
 		    if (!tree.hasOwnProperty(key) || !_.isObject(tree[key])) {

--- a/tests.js
+++ b/tests.js
@@ -124,6 +124,10 @@ var basicTests = function() {
                     [];
                 }),
             "Empty array matches [,]");
+            
+        ok(Structured.match("var myVar = \"abc I love strings!\"", function() {
+            var _ = "abc I love strings!";
+        }), "\"text\" will match 'text'")
     });
 
     test("Negative tests of syntax", function() {

--- a/tests.js
+++ b/tests.js
@@ -126,8 +126,12 @@ var basicTests = function() {
             "Empty array matches [,]");
             
         ok(Structured.match("var myVar = \"abc I love strings!\"", function() {
+            var _ = 'abc I love strings!';
+        }), "\"text\" matches 'text'");
+        
+        ok(Structured.match("var myVar = 'abc I love strings!'", function() {
             var _ = "abc I love strings!";
-        }), "\"text\" will match 'text'")
+        }), "'text' matches \"text\"");
     });
 
     test("Negative tests of syntax", function() {

--- a/tests.js
+++ b/tests.js
@@ -132,6 +132,11 @@ var basicTests = function() {
         ok(Structured.match("var myVar = 'abc I love strings!'", function() {
             var _ = "abc I love strings!";
         }), "'text' matches \"text\"");
+        
+        ok(Structured.match("var empty1 = '';var empty2 = \"\"", function() {
+            var _ = '';
+            var _ = "";
+        }), "Quote style of empty string is ignored");
     });
 
     test("Negative tests of syntax", function() {


### PR DESCRIPTION
This pull request intends to fix issue #22 by rewriting the `raw` property of Literal nodes in the `standardizeTree` method. Strings are rewritten so that they all use double quotes for open and close and any quotes contained within will be escaped double quotes.

If any changes are needed before this PR can be merged just let me know and I'll implement them ASAP.

Thank you for your time.